### PR TITLE
Add bower configuration to support legacy packages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,35 @@
+{
+  "name": "jspanel4",
+  "version": "4.1.1",
+  "authors": [
+    "Stefan Straesser <info@jspanel.de> (http://jspanel.de/)"
+  ],
+  "homepage": "http://jspanel.de",
+  "license": "MIT",
+  "keywords": [
+    "javascript",
+    "jsPanel",
+    "panel",
+    "floating panel",
+    "ui",
+    "layout",
+    "popup",
+    "widget",
+    "window",
+    "modal",
+    "tooltip",
+    "hint",
+    "alert",
+    "notifier",
+    "contextmenu",
+    "bootstrap"
+  ],
+  "main": [
+    "dist/jspanel.js",
+    "dist/jspanel.css"
+  ],
+  "bugs": {
+    "url": "https://github.com/Flyer53/jsPanel4/issues",
+    "email": "info@jspanel.de"
+  }
+}


### PR DESCRIPTION
There are several packages which are based on bower. However, we have to add a bower.json file to support them. This is a basic configuration to allow install the jspanel vi bower.