### PR TITLE
Fix replacement logo max height

### DIFF
--- a/source/jspanel.sass
+++ b/source/jspanel.sass
@@ -287,7 +287,7 @@
 
         img
           max-width: 100px
-          max-height: 38px
+          max-height: 34px
 
     .jsPanel-titlebar
       cursor: default


### PR DESCRIPTION
This fixes the maximum height of the logo in the minified state. Currently, it is 4px too big, because the height of the replacement panel is defined as 34px here: https://github.com/Flyer53/jsPanel4/compare/master...cmfcmf:fix-replacement-height?expand=1#diff-3a74bde183aa27c27192c060fe5e8f9eR275

---

I could not find any information on how to re-generate the `dist` and `es6modules` folders. I think it would be a good idea to add the necessary command(s) to the README, what do you think?