### PR TITLE
added check for self.parentElement before attempting to remove

### DIFF
--- a/source/jspanel.js
+++ b/source/jspanel.js
@@ -2619,7 +2619,9 @@ let jsPanel = {
         };
         self.remove = (id, closedBy, cb) => {
             // self.remove() is just a helper func used in self.close()
-            self.parentElement.removeChild(self);
+            if (self.parentElement) {
+                self.parentElement.removeChild(self);
+            }
             if (!document.getElementById(id)) {
                 self.removeMinimizedReplacement();
                 self.status = 'closed';


### PR DESCRIPTION
Hi Stefan. I came across this issue in my implementation. There is a step in the code that does: self.parentElement.removeChild(self), but sometimes self.parentElement does not exist and causes an error. I wrapped it in an if statement to first check for self.parentElement and it fixed the problem. Thank you.